### PR TITLE
Bug fix that will prevent heal potions wasting;

### DIFF
--- a/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoPot.kt
+++ b/src/main/java/net/ccbluex/liquidbounce/features/module/modules/combat/AutoPot.kt
@@ -156,7 +156,7 @@ class AutoPot : Module() {
             }
         } else if (utilityValue.get()) {
             for (potionEffect in itemPotion.getEffects(stack)) {
-                if (InventoryUtils.isPositivePotionEffect(potionEffect.potionID) && !mc.thePlayer.isPotionActive(potionEffect.potionID)) {
+                if (potionEffect.potionID != Potion.heal.id && InventoryUtils.isPositivePotionEffect(potionEffect.potionID) && !mc.thePlayer.isPotionActive(potionEffect.potionID)) {
                     return true
                 }
             }


### PR DESCRIPTION
mc.thePlayer.isPotionActive(Potion.heal.id) always returns false because a potion with Instant Health effect doesn't have duration;